### PR TITLE
Added a comment on the domain-joiner account format

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ AD-Joined session hosts requires the following:
 - Non-overlapping private IP space
 - Domain Controller in Azure
 - Permissions to peer the AVD vnet with DC vnet
-- Domain-joiner account credentials and OU path
+- Domain-joiner account credentials and OU path (use user@domain.xyz format otherwise domain join will fail)
 
 Depending on which option you choose, you will need to use the appropriate parameters-\*.json file. There are sample values in each of these files.
 


### PR DESCRIPTION
Providing a domain user in the format <username> will fail to domain join, even if the domain is given in the domainToJoin variable.

It's important to mention this because in Terraform I see the <username> format most of the time and I've been struggling to identify why the domain join was failing (i.e. because we need username@domain.xyz format)

Thanks for the great work Paul!